### PR TITLE
Feat: Add `material.entity` To `module`

### DIFF
--- a/src/materials/materials.module.ts
+++ b/src/materials/materials.module.ts
@@ -1,9 +1,12 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { MaterialsController } from './materials.controller';
 import { MaterialsService } from './materials.service';
+import { Material } from './entities/material.entity';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([Material])],
   controllers: [MaterialsController],
-  providers: [MaterialsService]
+  providers: [MaterialsService],
 })
 export class MaterialsModule {}


### PR DESCRIPTION
- Import `TypeOrmModule` from NestJS 'typeorm' package
- Import 'Material' class
- Add 'Material' as a feature to the Module imports

Closes #23