### PR TITLE
Feat: Add 'landmark_count' Field To 'coordinate' Entity

### DIFF
--- a/src/coordinates/entities/coordinate.entity.ts
+++ b/src/coordinates/entities/coordinate.entity.ts
@@ -19,4 +19,7 @@ export class Coordinate {
 
   @Column()
   landmark_id: number;
+
+  @Column()
+  landmark_count: number;
 }


### PR DESCRIPTION
By implementing this PR we are now adding the ability for our 'coordinate' table to retain the 'landmark_count' for how many 'landmark_id''s can be found at that particular coordinate (which will be helpful for both accuracy and potential heat mapping down the line).

Closes #40 