### PR TITLE
Connect 'service' To 'repo'; Configure 'create'

### DIFF
--- a/src/common-locations/common-locations.service.ts
+++ b/src/common-locations/common-locations.service.ts
@@ -1,4 +1,18 @@
 import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { CommonLocation } from './entities/common-location.entity';
 
 @Injectable()
-export class CommonLocationsService {}
+export class CommonLocationsService {
+  constructor(
+    @InjectRepository(CommonLocation)
+    private readonly repo: Repository<CommonLocation>,
+  ) {}
+
+  create(name: string) {
+    const commonLocation = this.repo.create({ name });
+
+    return this.repo.save(commonLocation);
+  }
+}


### PR DESCRIPTION
**Before The PR (Pull Request):**
Before the PR there was no connection between the 'repo' / database and the 'service' which prevented us from persisting and accessing our data.

**After The PR (Pull Request):**
After the PR we had established a connection between the 'repo' / database and the 'service' which has now enabled us to persist data - specifically to 'create' a record row within the database.

**What Was Changed?**
- Import `InjectRepository` decorator
- Import `Repository` class
- Import `CommonLocation` entity
- Add a `constructor` to service class, establishing repo connection through dependency injection
- Add `create()` method to 'upsert' a record into the repo

**Why Was This Changed?**
In order to persist data in our database we need to have established a connection to the repo in our 'service.ts' file for the particular module we'll be working in. Creating a constructor, we used dependency injection to establish a connection to the repository (thereby connecting to the database). 

Instantiating a `create()` method allows us to actually persist data in our database through the use of our 'repo'.

**Related Issues Resolved By This PR (Pull Request):** _(Type `#` then the issue number)_
Resolves #71 

**Mentions:** _(Type `@` then the person's name)_
N / A