### PR TITLE
Add Relations Between 'material' & 'unique_cooking_effect' Entities

### DIFF
--- a/src/materials/dtos/create-material.dto.ts
+++ b/src/materials/dtos/create-material.dto.ts
@@ -1,4 +1,5 @@
 import { IsBoolean, IsNumber, IsOptional, IsString } from 'class-validator';
+import { UniqueCookingEffect } from '../../unique-cooking-effects/entities/unique-cooking-effect.entity';
 
 export class CreateMaterialDto {
   @IsNumber()
@@ -19,7 +20,7 @@ export class CreateMaterialDto {
 
   @IsString()
   @IsOptional()
-  readonly unique_cooking_effect: string;
+  readonly unique_cooking_effect: UniqueCookingEffect;
 
   @IsString({ each: true })
   readonly common_locations: string[];

--- a/src/materials/dtos/create-material.dto.ts
+++ b/src/materials/dtos/create-material.dto.ts
@@ -1,5 +1,4 @@
 import { IsBoolean, IsNumber, IsOptional, IsString } from 'class-validator';
-import { UniqueCookingEffect } from '../../unique-cooking-effects/entities/unique-cooking-effect.entity';
 
 export class CreateMaterialDto {
   @IsNumber()
@@ -17,10 +16,6 @@ export class CreateMaterialDto {
   @IsNumber()
   @IsOptional()
   readonly hearts_recovered: number;
-
-  @IsString()
-  @IsOptional()
-  readonly unique_cooking_effect: UniqueCookingEffect;
 
   @IsString({ each: true })
   readonly common_locations: string[];

--- a/src/materials/dtos/update-material.dto.ts
+++ b/src/materials/dtos/update-material.dto.ts
@@ -1,4 +1,5 @@
 import { IsBoolean, IsNumber, IsOptional, IsString } from 'class-validator';
+import { UniqueCookingEffect } from '../../unique-cooking-effects/entities/unique-cooking-effect.entity';
 
 export class UpdateMaterialDto {
   @IsNumber()
@@ -23,7 +24,7 @@ export class UpdateMaterialDto {
 
   @IsString()
   @IsOptional()
-  readonly unique_cooking_effect: string;
+  readonly unique_cooking_effect: UniqueCookingEffect;
 
   @IsString({ each: true })
   @IsOptional()

--- a/src/materials/entities/material.entity.ts
+++ b/src/materials/entities/material.entity.ts
@@ -21,7 +21,7 @@ export class Material {
   @ManyToOne(
     () => UniqueCookingEffect,
     (uniqueCookingEffect) => uniqueCookingEffect.materials,
-    { cascade: ['insert', 'update', 'remove'], nullable: true },
+    { nullable: true },
   )
   unique_cooking_effect: UniqueCookingEffect;
 

--- a/src/materials/entities/material.entity.ts
+++ b/src/materials/entities/material.entity.ts
@@ -1,4 +1,5 @@
-import { Entity, Column, PrimaryColumn } from 'typeorm';
+import { Entity, Column, PrimaryColumn, ManyToOne } from 'typeorm';
+import { UniqueCookingEffect } from '../../unique-cooking-effects/entities/unique-cooking-effect.entity';
 
 @Entity()
 export class Material {
@@ -17,8 +18,12 @@ export class Material {
   @Column({ nullable: true })
   hearts_recovered: number;
 
-  @Column({ nullable: true })
-  unique_cooking_effect: string;
+  @ManyToOne(
+    () => UniqueCookingEffect,
+    (uniqueCookingEffect) => uniqueCookingEffect.materials,
+    { cascade: ['insert', 'update', 'remove'], nullable: true },
+  )
+  unique_cooking_effect: UniqueCookingEffect;
 
   @Column('json')
   common_locations: string[];

--- a/src/materials/materials.controller.ts
+++ b/src/materials/materials.controller.ts
@@ -8,7 +8,6 @@ import {
   Post,
 } from '@nestjs/common';
 import { MaterialsService } from './materials.service';
-import { CreateMaterialDto } from './dtos/create-material.dto';
 import { UpdateMaterialDto } from './dtos/update-material.dto';
 
 @Controller('materials')
@@ -16,16 +15,25 @@ export class MaterialsController {
   constructor(private readonly materialsService: MaterialsService) {}
 
   @Post()
-  createMaterial(@Body() body: CreateMaterialDto) {
+  createMaterial(
+    @Body('id') id: number,
+    @Body('name') name: string,
+    @Body('description') description: string,
+    @Body('fuse_attack_power') fuse_attack_power: number,
+    @Body('hearts_recovered') hearts_recovered: number,
+    @Body('common_locations') common_locations: string[],
+    @Body('tradeable') tradeable: boolean,
+    @Body('unique_cooking_effect') unique_cooking_effect: string,
+  ) {
     return this.materialsService.create(
-      body.id,
-      body.name,
-      body.description,
-      body.fuse_attack_power,
-      body.hearts_recovered,
-      body.unique_cooking_effect,
-      body.common_locations,
-      body.tradeable,
+      id,
+      name,
+      description,
+      fuse_attack_power,
+      hearts_recovered,
+      common_locations,
+      tradeable,
+      unique_cooking_effect,
     );
   }
 

--- a/src/materials/materials.module.ts
+++ b/src/materials/materials.module.ts
@@ -3,9 +3,10 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { MaterialsController } from './materials.controller';
 import { MaterialsService } from './materials.service';
 import { Material } from './entities/material.entity';
+import { UniqueCookingEffectsModule } from 'src/unique-cooking-effects/unique-cooking-effects.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Material])],
+  imports: [TypeOrmModule.forFeature([Material]), UniqueCookingEffectsModule],
   controllers: [MaterialsController],
   providers: [MaterialsService],
 })

--- a/src/materials/materials.service.ts
+++ b/src/materials/materials.service.ts
@@ -6,6 +6,7 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Material } from './entities/material.entity';
+import { UniqueCookingEffect } from '../unique-cooking-effects/entities/unique-cooking-effect.entity';
 
 @Injectable()
 export class MaterialsService {
@@ -19,14 +20,16 @@ export class MaterialsService {
     description: string,
     fuse_attack_power: number,
     hearts_recovered: number,
-    unique_cooking_effect: string,
+    unique_cooking_effect: UniqueCookingEffect,
     common_locations: string[],
     tradeable: boolean,
   ) {
+    console.log('Creating Potential Duplicate...');
     const potentialDuplicateMaterial = await this.repo.find({
       where: { name },
     });
 
+    console.log('Potential Duplicate Object Created...');
     if (potentialDuplicateMaterial.length !== 0) {
       const { id, name } = potentialDuplicateMaterial[0];
 
@@ -34,6 +37,8 @@ export class MaterialsService {
         `A 'material' record with a 'name' of ${name} already exists as id #${id}`,
       );
     }
+
+    console.log('No Duplicates, Attempting To Create Record Row...');
 
     const material = this.repo.create({
       id,
@@ -46,6 +51,8 @@ export class MaterialsService {
       tradeable,
     });
 
+    console.log('Record Row Object Successfully Created...');
+
     return this.repo.save(material);
   }
 
@@ -57,7 +64,7 @@ export class MaterialsService {
         description: true,
         fuse_attack_power: true,
         hearts_recovered: true,
-        unique_cooking_effect: true,
+        unique_cooking_effect: { name: true },
         common_locations: true,
         tradeable: true,
       },

--- a/src/materials/materials.service.ts
+++ b/src/materials/materials.service.ts
@@ -87,6 +87,9 @@ export class MaterialsService {
         common_locations: true,
         tradeable: true,
       },
+      relations: {
+        unique_cooking_effect: true,
+      },
     });
   }
 

--- a/src/materials/materials.service.ts
+++ b/src/materials/materials.service.ts
@@ -33,13 +33,6 @@ export class MaterialsService {
     );
 
     /**
-     * 2. Validate presence of unique_cooking_effect value; throw err if absent
-     */
-    if (potentialUniqueCookingEffect.length === 0) {
-      throw new ConflictException("No such 'unique_cooking_effect' exists");
-    }
-
-    /**
      * 3. Check to see if we can return a value for the material
      */
     const potentialMaterial = await this.repo.find({
@@ -70,7 +63,7 @@ export class MaterialsService {
       tradeable,
     });
 
-    Object.assign(material, potentialUniqueCookingEffect);
+    material.unique_cooking_effect = potentialUniqueCookingEffect[0];
 
     return this.repo.save(material);
   }

--- a/src/unique-cooking-effects/dtos/create-unique-cooking-effect.dto.ts
+++ b/src/unique-cooking-effects/dtos/create-unique-cooking-effect.dto.ts
@@ -1,4 +1,5 @@
 import { IsString } from 'class-validator';
+import { Material } from '../../materials/entities/material.entity';
 
 export class CreateUniqueCookingEffectDto {
   @IsString()
@@ -6,4 +7,6 @@ export class CreateUniqueCookingEffectDto {
 
   @IsString()
   description: string;
+
+  materials: Material[];
 }

--- a/src/unique-cooking-effects/dtos/update-unique-cooking-effect.dto.ts
+++ b/src/unique-cooking-effects/dtos/update-unique-cooking-effect.dto.ts
@@ -1,4 +1,5 @@
 import { IsString, IsOptional } from 'class-validator';
+import { Material } from '../../materials/entities/material.entity';
 
 export class UpdateUniqueCookingEffectDto {
   @IsString()
@@ -8,4 +9,6 @@ export class UpdateUniqueCookingEffectDto {
   @IsString()
   @IsOptional()
   description: string;
+
+  materials: Material[];
 }

--- a/src/unique-cooking-effects/entities/unique-cooking-effect.entity.ts
+++ b/src/unique-cooking-effects/entities/unique-cooking-effect.entity.ts
@@ -1,4 +1,5 @@
-import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, Entity, PrimaryGeneratedColumn, OneToMany } from 'typeorm';
+import { Material } from '../../materials/entities/material.entity';
 
 @Entity()
 export class UniqueCookingEffect {
@@ -10,4 +11,7 @@ export class UniqueCookingEffect {
 
   @Column()
   description: string;
+
+  @OneToMany(() => Material, (material) => material.unique_cooking_effect)
+  materials: Material[];
 }

--- a/src/unique-cooking-effects/unique-cooking-effects.controller.ts
+++ b/src/unique-cooking-effects/unique-cooking-effects.controller.ts
@@ -24,12 +24,12 @@ export class UniqueCookingEffectsController {
 
   @Get()
   findAllUniqueCookingEffects() {
-    return this.uniqueCookingEffectsService.find();
+    return this.uniqueCookingEffectsService.findAll();
   }
 
   @Get('/:id')
   findUniqueCookingEffect(@Param('id') id: string) {
-    return this.uniqueCookingEffectsService.findOne(parseInt(id));
+    return this.uniqueCookingEffectsService.findById(parseInt(id));
   }
 
   @Patch('/:id')

--- a/src/unique-cooking-effects/unique-cooking-effects.module.ts
+++ b/src/unique-cooking-effects/unique-cooking-effects.module.ts
@@ -8,5 +8,6 @@ import { UniqueCookingEffectsService } from './unique-cooking-effects.service';
   imports: [TypeOrmModule.forFeature([UniqueCookingEffect])],
   controllers: [UniqueCookingEffectsController],
   providers: [UniqueCookingEffectsService],
+  exports: [UniqueCookingEffectsService],
 })
 export class UniqueCookingEffectsModule {}

--- a/src/unique-cooking-effects/unique-cooking-effects.service.ts
+++ b/src/unique-cooking-effects/unique-cooking-effects.service.ts
@@ -32,7 +32,7 @@ export class UniqueCookingEffectsService {
     return this.repo.save(uniqueCookingEffect);
   }
 
-  find() {
+  findAll() {
     return this.repo.find({
       select: {
         name: true,
@@ -41,12 +41,18 @@ export class UniqueCookingEffectsService {
     });
   }
 
-  findOne(id: number) {
+  findByName(name: string) {
+    return this.repo.find({
+      where: { name },
+    });
+  }
+
+  findById(id: number) {
     return this.repo.findOneBy({ id });
   }
 
   async update(id: number, attrs: Partial<UniqueCookingEffect>) {
-    const uniqueCookingEffect = await this.findOne(id);
+    const uniqueCookingEffect = await this.findById(id);
 
     if (!uniqueCookingEffect) {
       throw new NotFoundException();
@@ -58,7 +64,7 @@ export class UniqueCookingEffectsService {
   }
 
   async remove(id: number) {
-    const uniqueCookingEffect = await this.findOne(id);
+    const uniqueCookingEffect = await this.findById(id);
 
     if (!uniqueCookingEffect) {
       throw new NotFoundException();

--- a/src/unique-cooking-effects/unique-cooking-effects.service.ts
+++ b/src/unique-cooking-effects/unique-cooking-effects.service.ts
@@ -35,8 +35,13 @@ export class UniqueCookingEffectsService {
   findAll() {
     return this.repo.find({
       select: {
+        id: true,
         name: true,
         description: true,
+        materials: { name: true },
+      },
+      relations: {
+        materials: true,
       },
     });
   }


### PR DESCRIPTION
**Before The PR (Pull Request):**
Prior to this PR there was no way to instantiate a relationship between the 'unique_cooking_effect' field in the 'material' table and the 'materials' field in the 'unique_cooking_effect' table, thus depriving future Users of the ability to see, specifically, the information that they may be looking for.

**After The PR (Pull Request):**
With this PR relationships are created between the 'material' and 'unique_cooking_effect' table. Upon making a POST request to the 'materials' route the User can establish a relation between any pre-existing 'unique_cooking_effect' record that exists in the appropriate table. All other related routes (i.e. `/materials`, `/unique-cooking-effects`) help to facilitate those relationships.

**What Was Changed?**
| File Name | Changes |
| --- | --- |
| `create-material.dto.ts` | - Remove 'unique_cooking_effect' field from the DTO |
| `update-material.dto.ts` | - Import 'UniqueCookingEffect' entity</br>- Amend 'unique_cooking_effect' field type to 'UniqueCookingEffect' entity |
| `material.entity.ts` | - Add 'ManyToOne' to TypeORM imports</br>- Import 'UniqueCookingEffect' entity</br>- Update 'unique_cooking_effect' field decorator from 'Column' to 'ManyToOne'</br>- Amend 'unique_cooking_effect' field type to 'UniqueCookingEffect' entity</br>- Pass relationship mapper as parameters to the 'ManyToOne' decorator |
| `materials.controller.ts` | - Remove 'CreateMaterialDto' import</br>- Deconstruct `createMaterial()` method parameters into specific '@Body()' decorator extractions</br>- Update values passed to `create()` method in the material service |
| `materials.module.ts` | - Import 'UniqueCookingEffectsModule'</br>- Add 'UniqueCookingEffectsModule' to `@Module()` decorator's 'imports' field |
| `materials.service.ts` | - Import 'UniqueCookingEffectsService'</br>- Add 'UniqueCookingEffectsService' to service's `controller()`</br>- Update `create()` method parameter order</br>- Update `create()` method business logic to account for establishing a new relationship</br>- Update `find()` method to display the 'name' key / value stored in the 'unique_cooking_effect' object |
| `create-unique-cooking-effect.dto.ts` | - Import 'Material' entity</br>- Add 'materials' field with a type of 'Material' array |
| `update-unique-cooking-effect.dto.ts` | - Import 'Material' entity</br>- Add 'materials' field with a type of 'Material' array |
| `unique-cooking-effect.entity.ts` | - Add 'OneToMany' to TypeORM imports</br>- Import 'Material' entity</br>- Update 'materials' field decorator from 'Column' to 'OneToMany'</br>- Amend 'materials' field type to array of 'Material' entity objects</br>- Pass relationship mapper as parameters to the 'OneToMany' decorator |
| `unique-cooking-effects.controller.ts` | - Amend `find()` method name to `findAll()`</br>- Amend `findOne()` method name to `findById()` |
| `unique-cooking-effects.module.ts` | - Add 'UniqueCookingEffectsService' to 'exports' key |
| `unique-cooking-effects.service.ts` | - Amend `find()` method name to `findAll()`</br>- Update returned values shown to the requestor</br>- Add `findByName()` method</br>- Amend `findOne()` method name to `findById()`</br>- Amend method names where method was called elsewhere in the class |

**Why Was This Changed?**
Prior to this PR there was no way to instantiate a relationship between the 'unique_cooking_effect' field in the 'material' table and the 'materials' field in the 'unique_cooking_effect' table, thus depriving future Users of the ability to see, specifically, the information that they may be looking for. With this PR those relationships are created and upon making a POST request to the 'materials' route the User can establish a relation between any pre-existing 'unique_cooking_effect' record that exists in the appropriate table. All other related routes (i.e. `/materials`, `/unique-cooking-effects`) help to facilitate those relationships.

**Related Issues Resolved By This PR (Pull Request):** _(Type `#` then the issue number)_
Resolves #66 

**Mentions:** _(Type `@` then the person's name)_
N / A